### PR TITLE
Fix secret vote service import path

### DIFF
--- a/src/commands/votes/secretvote.ts
+++ b/src/commands/votes/secretvote.ts
@@ -1,5 +1,5 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import SecretVoteService from '../../services/votes/secret-vote.service';
+import SecretVoteService from '../../services/secret-vote.service';
 import { addMentionOptions, ensureChannel, ensurePermissions } from '../../utils';
 import { config } from '../../config';
 


### PR DESCRIPTION
## Summary
- point secretvote command to the correct `secret-vote.service` location

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p .` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d5170ab7c8321af9a3f71c93518cb