### PR TITLE
Centralize shared types

### DIFF
--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -1,9 +1,15 @@
-import { PlayerStats2Model, IPlayerStats2 } from './models/playerStats2.model';
-import { SeasonStatsModel, ISeasonStats } from './models/seasonStats.model';
-import { PBCStatsModel, IPBCStats } from './models/pbcStats.model';
-import { Edition } from './models/edition.model';
-import { GameType } from './models/gameType.model';
-import { WaitingMatchModel, ValidatedMatchModel, IMatch } from './models/match.model';
+import { PlayerStats2Model } from './models/playerStats2.model';
+import { SeasonStatsModel } from './models/seasonStats.model';
+import { PBCStatsModel } from './models/pbcStats.model';
+import { WaitingMatchModel, ValidatedMatchModel } from './models/match.model';
+import {
+  Edition,
+  GameType,
+  IPlayerStats2,
+  ISeasonStats,
+  IPBCStats,
+  IMatch,
+} from './types';
 
 // Seasonal Stats queries
 export async function getAllSeasonStats(edition: Edition, gameType: GameType, minGames = 3): Promise<ISeasonStats[]> {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,0 +1,6 @@
+export { Edition } from './models/edition.model';
+export { GameType } from './models/gameType.model';
+export type { IPlayerStats2 } from './models/playerStats2.model';
+export type { ISeasonStats } from './models/seasonStats.model';
+export type { IPBCStats } from './models/pbcStats.model';
+export type { IMatch } from './models/match.model';

--- a/src/services/draft.service.ts
+++ b/src/services/draft.service.ts
@@ -12,7 +12,7 @@ import { civ7Leaders } from '../data/civ7';
 import { collectParticipants } from '../handlers';
 import { findGuildEmoji } from './emoji.service';
 import { VotingService } from './voting.service';
-import { GameType } from '../types/civ.types';
+import { GameType } from '../types/common.types';
 
 export default class DraftService {
   private voting = new VotingService();

--- a/src/types/civ.types.ts
+++ b/src/types/civ.types.ts
@@ -1,4 +1,4 @@
-export type GameType = 'civ6' | 'civ7';
+import { GameType } from './common.types';
 
 export interface Civ {
   civ: string;

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -2,6 +2,8 @@ export type UnixSeconds = number;
 
 export type SnowflakeString = string;
 
+export type GameType = 'civ6' | 'civ7';
+
 
 export interface VoteOption {
   emoji: string;

--- a/src/types/ui.types.ts
+++ b/src/types/ui.types.ts
@@ -1,0 +1,16 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  StringSelectMenuBuilder,
+  EmbedBuilder,
+} from 'discord.js';
+
+export type ButtonRow = ActionRowBuilder<ButtonBuilder>;
+export type SelectRow = ActionRowBuilder<StringSelectMenuBuilder>;
+
+export interface PaginationManagerOptions {
+  prefix: string;
+  embeds: EmbedBuilder[];
+  ephemeral?: boolean;
+  timeoutMs?: number;
+}

--- a/src/ui/buttons.ts
+++ b/src/ui/buttons.ts
@@ -5,9 +5,8 @@ import {
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder,
 } from 'discord.js';
+import { ButtonRow, SelectRow } from '../types/ui.types';
 
-export type ButtonRow = ActionRowBuilder<ButtonBuilder>;
-export type SelectRow = ActionRowBuilder<StringSelectMenuBuilder>;
 
 export function createYesNoRow(prefix: string, includeEmoji = true, disabled = false): ButtonRow {
   const yesLabel = includeEmoji ? '✅ Yes' : 'Yes';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,2 +1,3 @@
 export * from './buttons';
 export * from './pagination';
+export * from '../types/ui.types';

--- a/src/ui/pagination.ts
+++ b/src/ui/pagination.ts
@@ -6,13 +6,8 @@ import {
   EmbedBuilder,
 } from 'discord.js';
 import { createPaginationRow } from './buttons';
+import { PaginationManagerOptions } from '../types/ui.types';
 
-export interface PaginationManagerOptions {
-  prefix: string;
-  embeds: EmbedBuilder[];
-  ephemeral?: boolean;
-  timeoutMs?: number;
-}
 
 export class PaginationManager {
   private currentPage = 0;


### PR DESCRIPTION
## Summary
- collect UI types in `src/types/ui.types.ts`
- expose types via `src/ui/index.ts`
- centralize `GameType` in `common.types.ts`
- use new `GameType` import in civ and draft modules
- create `src/database/types.ts` and update queries imports

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d83f5187483219f1726c2b45f3496