### PR TITLE
Add blind voting mode

### DIFF
--- a/src/commands/votes/civ6draftvote.ts
+++ b/src/commands/votes/civ6draftvote.ts
@@ -17,11 +17,11 @@ const builder = new SlashCommandBuilder()
         { name: 'duel',  value: 'duel'  }
       )
   )
-  .addStringOption(option =>
+  .addBooleanOption(option =>
     option
-      .setName('Blind Mode')
-      .setDescription('Draft/Voting iva DMs')
-      .setRequired(true)
+      .setName('blind_mode')
+      .setDescription('Enable blind mode to vote via DMs')
+      .setRequired(false)
   );
 
 addMentionOptions(builder as SlashCommandBuilder);
@@ -29,5 +29,5 @@ addMentionOptions(builder as SlashCommandBuilder);
 export const data = builder as SlashCommandBuilder;
 
 export async function execute(interaction: ChatInputCommandInteraction) {
-  await new DraftService(interaction.client).startDraft(interaction, 'civ6');
+  await new DraftService().startDraft(interaction, 'civ6');
 }

--- a/src/commands/votes/civ7draftvote.ts
+++ b/src/commands/votes/civ7draftvote.ts
@@ -28,11 +28,11 @@ const builder = new SlashCommandBuilder()
         { name: 'Modern',      value: 'Modern_Age'       }
       )
   )
-  .addStringOption(option =>
+  .addBooleanOption(option =>
     option
-      .setName('Blind Mode')
-      .setDescription('Draft/Vote iva DMs')
-      .setRequired(true)
+      .setName('blind_mode')
+      .setDescription('Enable blind mode to vote via DMs')
+      .setRequired(false)
   );
 
 addMentionOptions(builder as SlashCommandBuilder);
@@ -40,5 +40,5 @@ addMentionOptions(builder as SlashCommandBuilder);
 export const data = builder as SlashCommandBuilder;
 
 export async function execute(interaction: ChatInputCommandInteraction) {
-  await new DraftService(interaction.client).startDraft(interaction, 'civ7');
+  await new DraftService().startDraft(interaction, 'civ7');
 }

--- a/src/controllers/voting.controller.ts
+++ b/src/controllers/voting.controller.ts
@@ -9,7 +9,7 @@ export class VotesController {
   }
 
   static async startCiv7Draft(interaction: ChatInputCommandInteraction) {
-    const service = new DraftService(interaction.client);
+    const service = new DraftService();
     return service.startDraft(interaction, 'civ7');
   }
 }

--- a/src/services/draft.service.ts
+++ b/src/services/draft.service.ts
@@ -27,6 +27,10 @@ export default class DraftService {
     interaction: ChatInputCommandInteraction,
     game: GameType
   ): Promise<void> {
+    const blind = interaction.options.getBoolean('blind_mode') ?? false;
+    if (blind) {
+      this.voting.enableBlindMode();
+    }
     if (!acquireVoteLock()) {
       await interaction.reply({
         content: `<@${interaction.user.id}> is already part of an ongoing vote – vote aborted.`,
@@ -106,6 +110,7 @@ export default class DraftService {
     } finally {
       lockedIds.forEach(releaseUserLock);
       releaseVoteLock();
+      this.voting.disableBlindMode();
     }
   }
 }

--- a/src/services/voting.service.ts
+++ b/src/services/voting.service.ts
@@ -4,7 +4,8 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  ComponentType
+  ComponentType,
+  ButtonInteraction
 } from 'discord.js';
 
 import { VoteSettings, VoteResult } from '../types/common.types';
@@ -14,6 +15,16 @@ import { EMOJI_FINISHED } from '../config/constants';
 import { withVoteSetupLock } from '../utils';
 
 export class VotingService {
+
+  private blindMode = false;
+
+  enableBlindMode() {
+    this.blindMode = true;
+  }
+
+  disableBlindMode() {
+    this.blindMode = false;
+  }
 
   async startVote(
     channel: TextChannel,
@@ -42,6 +53,7 @@ export class VotingService {
       );
     }
 
+
     const finishRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId('finish')
@@ -51,9 +63,18 @@ export class VotingService {
     );
     rows.push(finishRow);
 
+    const disabledRows: ActionRowBuilder<ButtonBuilder>[] = rows.map(row => {
+      const r = new ActionRowBuilder<ButtonBuilder>();
+      for (const c of row.components as ButtonBuilder[]) {
+        r.addComponents(ButtonBuilder.from(c).setDisabled(true));
+      }
+      return r;
+    });
+
     message = await channel.send({
-      content: `Voting started. Use the buttons below to vote.`,
-      components: rows,
+      content: `Voting started. Use the buttons below to vote.` +
+        (this.blindMode ? ' Check your DMs to participate.' : ''),
+      components: this.blindMode ? disabledRows : rows,
     });
 
     try {
@@ -61,46 +82,100 @@ export class VotingService {
       const votes = new Map<string, Set<string>>();
       const finished = new Set<string>();
 
-    const collector = message.createMessageComponentCollector({
-      componentType: ComponentType.Button,
-      time: settings.timeoutMs ?? 120000,
-    });
+    if (this.blindMode) {
+      await Promise.all(
+        members.map(async member => {
+          const dm = await member.createDM();
+          const dmMessage = await dm.send({
+            content: `Voting started in **${channel.name}**. Use the buttons below to vote.`,
+            components: rows,
+          });
 
-      collector.on('collect', async i => {
+          const dmCollector = dmMessage.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            time: settings.timeoutMs ?? 120000,
+          });
+
+          dmCollector.on('collect', async (i: ButtonInteraction) => {
+            if (i.user.id !== member.id) {
+              await i.reply({ content: 'You are not part of this vote.', ephemeral: true });
+              return;
+            }
+
+            if (i.customId === 'finish') {
+              finished.add(i.user.id);
+              await i.reply({ content: 'Vote recorded.', ephemeral: true });
+              dmCollector.stop();
+              return;
+            }
+
+            const index = Number(i.customId.split('_')[1]);
+            const choice = voteOptions[index];
+            if (choice) {
+              const maxVotes = settings.maxVotesPerUser ?? 1;
+              const userVotes = votes.get(i.user.id) ?? new Set<string>();
+              if (userVotes.has(choice.label)) {
+                await i.reply({ content: 'You already voted for this option.', ephemeral: true });
+                return;
+              }
+              if (userVotes.size >= maxVotes) {
+                await i.reply({ content: 'You have no votes remaining for this category.', ephemeral: true });
+                return;
+              }
+              userVotes.add(choice.label);
+              votes.set(i.user.id, userVotes);
+              await i.reply({ content: 'Vote recorded.', ephemeral: true });
+            } else {
+              await i.deferUpdate();
+            }
+          });
+
+          await new Promise(resolve => dmCollector.once('end', resolve));
+          await dmMessage.edit({ components: [] }).catch(() => {});
+        })
+      );
+    } else {
+      const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: settings.timeoutMs ?? 120000,
+      });
+
+      collector.on('collect', async (i: ButtonInteraction) => {
         if (!members.some(m => m.id === i.user.id)) {
           await i.reply({ content: 'You are not part of this vote.', ephemeral: true });
           return;
         }
 
-      if (i.customId === 'finish') {
-        finished.add(i.user.id);
-        await i.reply({ content: 'Vote recorded.', ephemeral: true });
-        if (finished.size === members.length) collector.stop('finished');
-        return;
-      }
+        if (i.customId === 'finish') {
+          finished.add(i.user.id);
+          await i.reply({ content: 'Vote recorded.', ephemeral: true });
+          if (finished.size === members.length) collector.stop('finished');
+          return;
+        }
 
-      const index = Number(i.customId.split('_')[1]);
-      const choice = voteOptions[index];
-      if (choice) {
-        const maxVotes = settings.maxVotesPerUser ?? 1;
-        const userVotes = votes.get(i.user.id) ?? new Set<string>();
-        if (userVotes.has(choice.label)) {
-          await i.reply({ content: 'You already voted for this option.', ephemeral: true });
-          return;
+        const index = Number(i.customId.split('_')[1]);
+        const choice = voteOptions[index];
+        if (choice) {
+          const maxVotes = settings.maxVotesPerUser ?? 1;
+          const userVotes = votes.get(i.user.id) ?? new Set<string>();
+          if (userVotes.has(choice.label)) {
+            await i.reply({ content: 'You already voted for this option.', ephemeral: true });
+            return;
+          }
+          if (userVotes.size >= maxVotes) {
+            await i.reply({ content: 'You have no votes remaining for this category.', ephemeral: true });
+            return;
+          }
+          userVotes.add(choice.label);
+          votes.set(i.user.id, userVotes);
+          await i.reply({ content: 'Vote recorded.', ephemeral: true });
+        } else {
+          await i.deferUpdate();
         }
-        if (userVotes.size >= maxVotes) {
-          await i.reply({ content: 'You have no votes remaining for this category.', ephemeral: true });
-          return;
-        }
-        userVotes.add(choice.label);
-        votes.set(i.user.id, userVotes);
-        await i.reply({ content: 'Vote recorded.', ephemeral: true });
-      } else {
-        await i.deferUpdate();
-      }
       });
 
       await new Promise(resolve => collector.once('end', resolve));
+    }
 
       const tally: Record<string, number> = {};
       for (const opt of voteOptions) tally[opt.label] = 0;


### PR DESCRIPTION
## Summary
- add `blind_mode` option to civ6 and civ7 draft commands
- enable DM-based voting through `enableBlindMode` in `VotingService`
- integrate blind mode handling in `DraftService`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684f02a8f0e08321acc04d66c6aed858